### PR TITLE
VCST-4631: Shipping module calls /api/shipping/pickup-locations/indexedSearchEnabled before authentication (401)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,53 @@
-# Virto Commerce Shipping Module
+# Shipping Module
 
 [![CI status](https://github.com/VirtoCommerce/vc-module-shipping/workflows/Module%20CI/badge.svg?branch=dev)](https://github.com/VirtoCommerce/vc-module-shipping/actions?query=workflow%3A"Module+CI") [![Quality gate](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-shipping&metric=alert_status&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-shipping) [![Reliability rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-shipping&metric=reliability_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-shipping) [![Security rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-shipping&metric=security_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-shipping) [![Sqale rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-shipping&metric=sqale_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-shipping)
 
-The Shipping Module provides the ability to extend shipping provider list with custom providers and also provides an interface and API for managing these shipping providers.
+The Shipping Module provides the ability to extend the shipping provider list with custom providers and offers a UI and API for managing these shipping providers across stores. It ships with two built-in shipping methods — **Fixed Rate** and **Buy Online, Pickup In Store (BOPIS)** — and an extensibility point for registering additional methods from other modules.
 
-## Key features
+## Overview
 
-* Register shipping methods using the code
-* Receive the list of Shipping methods on UI on admin side
-* Edit shipping method settings
-* Connect the shipping methods to a Store
-* API to work with shipping method list
+Shipping methods are registered in code and then made available for configuration per store from the admin UI. Each method exposes its own set of settings (rates, surcharges, credentials, etc.) which are edited from the store's shipping tab. At checkout/quotation time the platform asks every active method for a rate, and the calculated rates are returned to the storefront.
+
+In addition to rate calculation, the module manages **pickup locations** used by BOPIS: dedicated entities with addresses, business hours, geo-coordinates and optional Google Maps integration. Pickup locations are indexed via the Search module so they can be looked up quickly on the storefront and in the admin UI.
+
+Key concepts:
+
+* **Shipping method** — a pluggable provider registered via DI that calculates shipping rates for a shipment.
+* **Pickup location** — a physical point (store, locker, warehouse) where a customer can pick up an order under the BOPIS method.
+* **Store binding** — each shipping method is activated per store, with its own settings and priority.
+
+## Features
+
+* Register custom shipping methods in code and expose them to the admin UI.
+* Manage the full list of shipping methods from the admin UI, with priority and per-store activation.
+* Edit per-method settings directly from the store's shipping tab.
+* Built-in **Fixed Rate** shipping method with configurable Ground and Air rates.
+* Built-in **BOPIS** (Buy Online, Pickup In Store) shipping method with full pickup-location management.
+* **Pickup locations CRUD**: create, update, delete and search locations with address, contacts and geo-coordinates.
+* **Google Maps integration** for visualizing and picking pickup-location coordinates (optional, requires API key).
+* **Indexed search** for pickup locations via the Search module, with event-based re-indexation out of the box.
+* Permission-scoped access (`shipping:read`, `shipping:create`, `shipping:update`, `shipping:delete`) and a `SelectedStoreScope` to limit shipping management to specific stores.
+* Public REST API to work with shipping methods, pickup locations and indexed search.
+
+## Settings
+
+The module registers the following settings. They can be edited from **Settings → Shipping** in the admin UI, or overridden via `appsettings.json` like any other platform setting.
+
+### BOPIS (pickup locations)
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `Shipping.Bopis.GoogleMaps.Enabled` | Boolean | `false` | Enable Google Maps in the pickup-location editor to pick/visualize coordinates. |
+| `Shipping.Bopis.GoogleMaps.ApiKey` | Short text | *(empty)* | Google Maps JavaScript API key used when the setting above is enabled. Exposed to the frontend (`IsPublic`). |
+| `Shipping.Bopis.Search.EventBasedIndexation.Enabled` | Boolean | `true` | Re-index a pickup location as soon as it is created/updated/deleted, in addition to the scheduled indexing job. |
+| `VirtoCommerce.Search.IndexingJobs.IndexationDate.PickupLocation` | DateTime | *(unset)* | Checkpoint used by the pickup-location indexing job to track the last processed change. |
+
+### Fixed Rate shipping method
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `VirtoCommerce.Shipping.FixedRateShippingMethod.Ground.Rate` | Decimal | `0.00` | Flat rate applied when the Fixed Rate method quotes *Ground* delivery. |
+| `VirtoCommerce.Shipping.FixedRateShippingMethod.Air.Rate` | Decimal | `0.00` | Flat rate applied when the Fixed Rate method quotes *Air* delivery. |
 
 ## Documentation
 

--- a/src/VirtoCommerce.ShippingModule.Core/VirtoCommerce.ShippingModule.Core.csproj
+++ b/src/VirtoCommerce.ShippingModule.Core/VirtoCommerce.ShippingModule.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ShippingModule.Data.MySql/VirtoCommerce.ShippingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data.MySql/VirtoCommerce.ShippingModule.Data.MySql.csproj
@@ -3,15 +3,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ShippingModule.Data\VirtoCommerce.ShippingModule.Data.csproj" />

--- a/src/VirtoCommerce.ShippingModule.Data.PostgreSql/VirtoCommerce.ShippingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data.PostgreSql/VirtoCommerce.ShippingModule.Data.PostgreSql.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ShippingModule.Data\VirtoCommerce.ShippingModule.Data.csproj" />

--- a/src/VirtoCommerce.ShippingModule.Data.SqlServer/VirtoCommerce.ShippingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data.SqlServer/VirtoCommerce.ShippingModule.Data.SqlServer.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ShippingModule.Data\VirtoCommerce.ShippingModule.Data.csproj" />

--- a/src/VirtoCommerce.ShippingModule.Data/VirtoCommerce.ShippingModule.Data.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data/VirtoCommerce.ShippingModule.Data.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Data" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.ShippingModule.Web/Scripts/shipping.js
+++ b/src/VirtoCommerce.ShippingModule.Web/Scripts/shipping.js
@@ -6,12 +6,13 @@ if (AppDependencies != undefined) {
 }
 
 angular.module(moduleName, ['ngSanitize'])
-    .run(['platformWebApp.widgetService',
+    .run(['$rootScope',
+        'platformWebApp.widgetService',
         'platformWebApp.permissionScopeResolver',
         'virtoCommerce.storeModule.stores',
         'platformWebApp.bladeNavigationService',
         'virtoCommerce.shippingModule.pickupLocations',
-        function (widgetService, scopeResolver, stores, bladeNavigationService, pickupLocations) {
+        function ($rootScope, widgetService, scopeResolver, stores, bladeNavigationService, pickupLocations) {
 
             widgetService.registerWidget({
                 controller: 'virtoCommerce.shippingModule.storeShippingWidgetController',
@@ -38,13 +39,17 @@ angular.module(moduleName, ['ngSanitize'])
                 template: 'Modules/$(VirtoCommerce.Shipping)/Scripts/widgets/pickupLocationsAddressWidget.tpl.html'
             }, 'pickupLocationAddress');
 
-            pickupLocations.indexedSearchEnabled(function (data) {
-                if (data.result) {
-                    widgetService.registerWidget({
-                        controller: 'virtoCommerce.searchModule.indexWidgetController',
-                        template: 'Modules/$(VirtoCommerce.Search)/Scripts/widgets/index-widget.tpl.html',
-                        documentType: 'PickupLocation'
-                    }, 'pickupLocationIndex');
+            $rootScope.$on('loginStatusChanged', function (event, authContext) {
+                if (authContext.isAuthenticated) {
+                    pickupLocations.indexedSearchEnabled(function (data) {
+                        if (data.result) {
+                            widgetService.registerWidget({
+                                controller: 'virtoCommerce.searchModule.indexWidgetController',
+                                template: 'Modules/$(VirtoCommerce.Search)/Scripts/widgets/index-widget.tpl.html',
+                                documentType: 'PickupLocation'
+                            }, 'pickupLocationIndex');
+                        }
+                    });
                 }
             });
 

--- a/src/VirtoCommerce.ShippingModule.Web/VirtoCommerce.ShippingModule.Web.csproj
+++ b/src/VirtoCommerce.ShippingModule.Web/VirtoCommerce.ShippingModule.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <noWarn>1591;NU1608</noWarn>
+    <noWarn>1591</noWarn>
     <OutputType>Library</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/src/VirtoCommerce.ShippingModule.Web/module.manifest
+++ b/src/VirtoCommerce.ShippingModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Shipping</id>
   <version>3.1003.0</version>
   <version-tag />
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.1000.0" />
     <dependency id="VirtoCommerce.Store" version="3.1000.0" />

--- a/src/VirtoCommerce.ShippingModule.Web/package-lock.json
+++ b/src/VirtoCommerce.ShippingModule.Web/package-lock.json
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1865,16 +1865,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -1998,16 +1988,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {


### PR DESCRIPTION
## Description
fix: Shipping module calls /api/shipping/pickup-locations/indexedSearchEnabled before authentication (401)

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4631
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Shipping_3.1003.0-pr-67-ae8e.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primary functional change is a small auth-timing fix in the admin UI, but the PR also upgrades multiple platform/data package versions which could introduce integration/regression issues.
> 
> **Overview**
> Fixes an admin-side 401 by updating `shipping.js` to only call `pickupLocations.indexedSearchEnabled` (and register the Search index widget) after `loginStatusChanged` indicates an authenticated session.
> 
> Updates module dependencies to target VirtoCommerce Platform `3.1016.0` across Core/Data/Web projects (and bumps EF Core Design to `10.0.5`), refreshes `package-lock.json` for a few transitive dev dependencies, and significantly expands the `README.md` with updated module overview/features/settings documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8ed452667b19c65e509006f5a7b50bacc0d3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->