### PR TITLE
VCST-5163: Stable 15 — Shipping (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.ShippingModule.Core/VirtoCommerce.ShippingModule.Core.csproj
+++ b/src/VirtoCommerce.ShippingModule.Core/VirtoCommerce.ShippingModule.Core.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ShippingModule.Data.MySql/VirtoCommerce.ShippingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data.MySql/VirtoCommerce.ShippingModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ShippingModule.Data\VirtoCommerce.ShippingModule.Data.csproj" />

--- a/src/VirtoCommerce.ShippingModule.Data.PostgreSql/VirtoCommerce.ShippingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data.PostgreSql/VirtoCommerce.ShippingModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ShippingModule.Data\VirtoCommerce.ShippingModule.Data.csproj" />

--- a/src/VirtoCommerce.ShippingModule.Data.SqlServer/VirtoCommerce.ShippingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data.SqlServer/VirtoCommerce.ShippingModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ShippingModule.Data\VirtoCommerce.ShippingModule.Data.csproj" />

--- a/src/VirtoCommerce.ShippingModule.Data/ExportImport/ShippingExportImport.cs
+++ b/src/VirtoCommerce.ShippingModule.Data/ExportImport/ShippingExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
@@ -30,12 +31,12 @@ public class ShippingExportImport(
         await using var sw = new StreamWriter(outStream);
         await using var writer = new JsonTextWriter(sw);
 
-        await writer.WriteStartObjectAsync();
+        await writer.WriteStartObjectAsync(cancellationToken);
 
         progressInfo.Description = "Shipping methods are started to export";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("ShippingMethods");
+        await writer.WritePropertyNameAsync("ShippingMethods", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -52,7 +53,7 @@ public class ShippingExportImport(
             progressCallback(progressInfo);
         }, cancellationToken);
 
-        await writer.WritePropertyNameAsync("PickupLocations");
+        await writer.WritePropertyNameAsync("PickupLocations", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -68,8 +69,8 @@ public class ShippingExportImport(
             progressCallback(progressInfo);
         }, cancellationToken);
 
-        await writer.WriteEndObjectAsync();
-        await writer.FlushAsync();
+        await writer.WriteEndObjectAsync(cancellationToken);
+        await writer.FlushAsync(cancellationToken);
     }
 
     public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
@@ -80,7 +81,7 @@ public class ShippingExportImport(
 
         using var streamReader = new StreamReader(inputStream);
         await using var reader = new JsonTextReader(streamReader);
-        while (await reader.ReadAsync())
+        while (await reader.ReadAsync(cancellationToken))
         {
             if (reader.TokenType == JsonToken.PropertyName && reader.Value?.ToString() == "ShippingMethods")
             {

--- a/src/VirtoCommerce.ShippingModule.Data/ExportImport/ShippingExportImport.cs
+++ b/src/VirtoCommerce.ShippingModule.Data/ExportImport/ShippingExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -19,7 +20,7 @@ public class ShippingExportImport(
 {
     private const int _batchSize = 50;
 
-    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -71,7 +72,7 @@ public class ShippingExportImport(
         await writer.FlushAsync();
     }
 
-    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.ShippingModule.Data/VirtoCommerce.ShippingModule.Data.csproj
+++ b/src/VirtoCommerce.ShippingModule.Data/VirtoCommerce.ShippingModule.Data.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Data" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Data" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ShippingModule.Core\VirtoCommerce.ShippingModule.Core.csproj" />

--- a/src/VirtoCommerce.ShippingModule.Web/Module.cs
+++ b/src/VirtoCommerce.ShippingModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -166,13 +167,13 @@ namespace VirtoCommerce.ShippingModule.Web
         }
 
         public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-          ICancellationToken cancellationToken)
+          CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<ShippingExportImport>().DoExportAsync(outStream, progressCallback, cancellationToken);
         }
 
         public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<ShippingExportImport>().DoImportAsync(inputStream, progressCallback, cancellationToken);
         }

--- a/src/VirtoCommerce.ShippingModule.Web/module.manifest
+++ b/src/VirtoCommerce.ShippingModule.Web/module.manifest
@@ -3,11 +3,11 @@
   <id>VirtoCommerce.Shipping</id>
   <version>3.1005.0</version>
   <version-tag />
-  <platformVersion>3.1016.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
   </dependencies>
   <title>Shipping</title>
   <description>Add shipping methods management</description>

--- a/src/VirtoCommerce.ShippingModule.Web/package-lock.json
+++ b/src/VirtoCommerce.ShippingModule.Web/package-lock.json
@@ -866,9 +866,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1367,9 +1367,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1660,7 +1660,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/tests/VirtoCommerce.ShippingModule.Data.Tests/VirtoCommerce.ShippingModule.Data.Tests.csproj
+++ b/tests/VirtoCommerce.ShippingModule.Data.Tests/VirtoCommerce.ShippingModule.Data.Tests.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 4). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–3 packages on nuget.org. Version handled by CI.

- ICancellationToken→CancellationToken migration.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Export/import cancellation behavior changes with platform API upgrades; dependency version bumps can surface breaking changes from upstream Virto packages at runtime.
> 
> **Overview**
> Aligns the Shipping module with **Stable 15** by bumping VirtoCommerce platform and related module package references to **3.1039.0** (and matching Core, Store, Search versions) across `.csproj` files and `module.manifest`.
> 
> Replaces the platform **`ICancellationToken`** abstraction with **`System.Threading.CancellationToken`** on module export/import entry points (`Module.ExportAsync` / `ImportAsync`) and in **`ShippingExportImport`**, including passing the token into Newtonsoft **`JsonTextWriter`** / **`JsonTextReader`** async APIs so long-running export/import can be cancelled consistently with the updated platform contracts.
> 
> Test tooling updates **`coverlet.collector`** to 10.0.1; the Web **`package-lock.json`** picks up minor dev dependency bumps (e.g. `fast-uri`, `nanoid`, `postcss`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a3b529706f905d5786f03652b09e6b8c5cd7463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Shipping_3.1005.0-pr-68-7a3b.zip